### PR TITLE
REFACTOR #8 : 부스 service 및 controller 반환 값 형식 변경

### DIFF
--- a/src/main/java/likelion/festival/booth/application/BoothService.java
+++ b/src/main/java/likelion/festival/booth/application/BoothService.java
@@ -1,6 +1,10 @@
 package likelion.festival.booth.application;
 
-import likelion.festival.booth.application.dto.*;
+import likelion.festival.booth.application.dto.BoothCreate;
+import likelion.festival.booth.application.dto.BoothDayLocationDto;
+import likelion.festival.booth.application.dto.BoothDto;
+import likelion.festival.booth.application.dto.BoothFilterDto;
+import likelion.festival.booth.application.dto.BoothUpdate;
 import likelion.festival.booth.domain.Booth;
 import likelion.festival.booth.domain.repository.BoothRepository;
 import likelion.festival.global.exception.WrongBoothId;
@@ -9,7 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor

--- a/src/main/java/likelion/festival/booth/domain/Booth.java
+++ b/src/main/java/likelion/festival/booth/domain/Booth.java
@@ -8,7 +8,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/likelion/festival/booth/ui/BoothController.java
+++ b/src/main/java/likelion/festival/booth/ui/BoothController.java
@@ -1,7 +1,11 @@
 package likelion.festival.booth.ui;
 
 import likelion.festival.booth.application.BoothService;
-import likelion.festival.booth.application.dto.*;
+import likelion.festival.booth.application.dto.BoothCreate;
+import likelion.festival.booth.application.dto.BoothDayLocationDto;
+import likelion.festival.booth.application.dto.BoothDto;
+import likelion.festival.booth.application.dto.BoothFilterDto;
+import likelion.festival.booth.application.dto.BoothUpdate;
 import likelion.festival.comment.appliction.CommentService;
 import likelion.festival.comment.appliction.dto.CommentRequestDto;
 import likelion.festival.comment.appliction.dto.CommentResponseDto;
@@ -12,7 +16,16 @@ import likelion.festival.menu.application.dto.MenuRequestDto;
 import likelion.festival.menu.application.dto.MenuResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.Cookie;
@@ -48,8 +61,8 @@ public class BoothController {
 
     @GetMapping
     public ResponseEntity<List<BoothDayLocationDto>> boothDayLocation(HttpServletRequest request,
-                                                      @RequestParam String day,
-                                                      @RequestParam String location
+                                                                      @RequestParam String day,
+                                                                      @RequestParam String location
     ) {
         List<BoothDayLocationDto> response = boothService.boothDayLocation(day, location);
         response.forEach(b -> b.updateIsLike(checkIsLike(request, b.getId())));
@@ -58,7 +71,7 @@ public class BoothController {
 
     @PostMapping()
     public ResponseEntity<Void> boothCreate(@RequestPart(value = "imgList", required = false) List<MultipartFile> imgList,
-                               @RequestParam(value = "boothDto") BoothCreate boothDto) {
+                                            @RequestParam(value = "boothDto") BoothCreate boothDto) {
         Long savedBoothId = boothService.create(boothDto);
         return ResponseEntity.created(URI.create("/api/booths/" + savedBoothId))
             .build();


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- service와 controller 사이에 domain을 주고 받는 것 및 불필요한 정보를 통신하는 것을 제거
    - domain이 controller까지 이어지는 것은 불필요한 비즈니스 로직을 presentLayer까지 이어지게 할 수 있다.(presentLayer의 책임을 벗어난다.)
    - 현재 연관관계를 맺고 있는 도메인들이 있는데 이를 잘못 작업하면 순환 참조가 발생할 수 있다.
    - 따라서 도메인 대신에 dto를 주고 받도록 수정했습니다.
- controller에서는 Http 규격 응답을 다룰 수 있는 ResponseEntity를 반환하도록 수정했습니다.
    - 결과를 항상 200으로 보내는 것보다는 생성된 결과는 201 삭제 결과는 204로 보내어 http 응답의 규격을 맞추는 것이 응답 정보를 명확하게 제시할 수 있다고 판단했습니다.

참고자료
- https://dev-ws.tistory.com/57

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항
- 삭제 시 반환값이 없는데 이 때에는 200을 응답값으로 보내는 것이 좋을까? 아니면 204를 상태코드로 응답하는 것이 좋을지 고민이 되네요

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #8 
